### PR TITLE
allow for omniauth 2.0 series

### DIFF
--- a/lib/omniauth-thebase/version.rb
+++ b/lib/omniauth-thebase/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Thebase
-    VERSION = "0.1.2"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/omniauth/strategies/thebase.rb
+++ b/lib/omniauth/strategies/thebase.rb
@@ -18,7 +18,7 @@ module OmniAuth
       end
 
       def callback_url
-        full_host + script_name + callback_path
+        full_host + callback_path
       end
     end
   end

--- a/omniauth-thebase.gemspec
+++ b/omniauth-thebase.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniAuth::Thebase::VERSION
 
-  gem.add_dependency 'omniauth', '~> 1.2'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.4'
+  gem.add_dependency 'omniauth', '~> 2.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
   gem.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Hi, @camelmasa

OmniAuth 2.0 was released includes to resolved a CSRF vulnerability and some behaviors changed.

See below the release note for details.
https://github.com/omniauth/omniauth/releases/tag/v2.0.0

This PR allow for OmniAuth 2.0 series.

I tested manually in remote server with https communication environment, and confirmed following.
  - should use omniauth 2.0 series.
  - should return credentials in auth hash. (regression scenarios)

If you want to try my branch, you can use like following in your Gemfile.
```rb
gem 'omniauth-thebase', github: 'koshilife/omniauth-thebase', branch: 'allow-for-omniauth-2.0'
```